### PR TITLE
Removing "version" from meta yml.

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -13,4 +13,4 @@ galaxy_info:
     - system
 dependencies:
   - grampajoe.docker-multi
-version: 1.0.0
+


### PR DESCRIPTION
Fires an error with ansible version 2.0.2.0

```
ERROR! 'version' is not a valid attribute for a RoleMetadata

The error appears to have been in '/home/jon/Projects/devshop/roles/grampajoe.rancher/meta/main.yml': line 2, column 1, but may
be elsewhere in the file depending on the exact syntax problem.

The offending line appears to be:

---
galaxy_info:
^ here

Ansible failed to complete successfully. Any error output should be
visible above. Please fix these errors and try again.
```
